### PR TITLE
Kernel heap & ktime `Instant` modification

### DIFF
--- a/mizu/kernel/.cargo/config.toml
+++ b/mizu/kernel/.cargo/config.toml
@@ -1,7 +1,3 @@
-[unstable]
-build-std = ["core", "compiler_builtins", "alloc", "panic_abort"]
-build-std-features = ["compiler-builtins-mem"]
-
 [target.riscv64imac-unknown-none-elf]
 linker = "ld.lld"
 rustflags = [

--- a/mizu/kernel/Cargo.toml
+++ b/mizu/kernel/Cargo.toml
@@ -12,6 +12,7 @@ qemu-virt = ["config/qemu-virt"]
 # Local crates
 co-trap = {path = "../lib/co-trap"}
 config = {path = "../lib/config", default-features = false}
+kalloc = {path = "../lib/kalloc"}
 klog = {path = "../lib/klog"}
 ksync = {path = "../lib/ksync"}
 ktime = {path = "../lib/ktime"}

--- a/mizu/kernel/Makefile
+++ b/mizu/kernel/Makefile
@@ -7,7 +7,9 @@ KERNEL_ASM  := $(DEBUG_DIR)/$(KERNEL).asm
 
 CARGO_ARGS := --target $(TARGET) \
 	--no-default-features \
-	--features $(BOARD)
+	--features $(BOARD) \
+	-Zbuild-std=core,compiler_builtins,alloc,panic_abort \
+	-Zbuild-std-features=compiler-builtins-mem
 
 ifeq ($(MODE),release)
     CARGO_ARGS += --release

--- a/mizu/kernel/link.ld
+++ b/mizu/kernel/link.ld
@@ -51,6 +51,10 @@ SECTIONS
         _sstack = ALIGN(4K);
         . += _stack_size * _max_harts;
         _estack = ALIGN(8);
+
+        _sheap = ALIGN(4K);
+        . += _heap_size;
+        _eheap = ALIGN(8);
     }
 
     .tbss (NOLOAD) : ALIGN(8)
@@ -74,5 +78,6 @@ PHDRS
     tls PT_TLS FLAGS(4);
 }
 
+PROVIDE(_heap_size = 24M);
 PROVIDE(_stack_size = 4K);
 PROVIDE(_max_harts = 4);

--- a/mizu/kernel/src/main.rs
+++ b/mizu/kernel/src/main.rs
@@ -9,8 +9,10 @@
 
 mod rxx;
 
-// #[macro_use]
-// extern crate klog;
+#[macro_use]
+extern crate klog;
+
+extern crate alloc;
 
 use sbi_rt::{NoReason, Shutdown};
 
@@ -20,7 +22,9 @@ static mut X: i32 = 123;
 fn main(_hartid: usize) -> ! {
     unsafe { assert_eq!(X, 123) };
 
-    log::info!("Hello world!");
+    println!("Hello world!");
+    let vec = alloc::vec![1, 2, 3, 4, 5];
+    log::debug!("{vec:?}");
 
     sbi_rt::system_reset(Shutdown, NoReason);
     loop {

--- a/mizu/kernel/src/rxx.rs
+++ b/mizu/kernel/src/rxx.rs
@@ -31,6 +31,9 @@ unsafe extern "C" fn __rt_init(hartid: usize) {
 
         static _stdata: u32;
         static _etdata: u32;
+
+        static mut _sheap: u32;
+        static mut _eheap: u32;
     }
     if hartid == 0 {
         r0::zero_bss(&mut _sbss, &mut _ebss);
@@ -50,11 +53,14 @@ unsafe extern "C" fn __rt_init(hartid: usize) {
         );
     }
 
-    // Disable interrupt in `ksync`
+    // Disable interrupt in `ksync`.
     unsafe { ksync::disable() };
 
     // Init logger.
     unsafe { klog::init_logger(log::Level::Debug) };
+
+    // Init the kernel heap.
+    unsafe { kalloc::init(&mut _sheap, &mut _eheap) };
 
     unsafe {
         static mut A: usize = 12345;

--- a/mizu/lib/config/src/qemu-virt.rs
+++ b/mizu/lib/config/src/qemu-virt.rs
@@ -2,4 +2,5 @@ use num_rational::Ratio;
 
 pub const KERNEL_START: usize = 0x80200000;
 
-pub const TIME_FREQ: Ratio<u128> = Ratio::new_raw(1, 12_500_000);
+pub const TIME_FREQ: u128 = 12_500_000;
+pub const TIME_FREQ_M: Ratio<u128> = Ratio::new_raw(2, 25); // 10^6 / FREQ

--- a/mizu/lib/kalloc/Cargo.toml
+++ b/mizu/lib/kalloc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+name = "kalloc"
+version = "0.1.0"
+
+[dependencies]
+# Local crates
+ksync = {path = "../ksync"}
+# External crates
+buddy_system_allocator = {version = "0", default-features = false}
+spin = "0"

--- a/mizu/lib/kalloc/src/imp.rs
+++ b/mizu/lib/kalloc/src/imp.rs
@@ -30,3 +30,24 @@ unsafe impl GlobalAlloc for Allocator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alloc_dealloc() {
+        static mut SPACE: [u64; 256] = [0; 256];
+        let layout = Layout::from_size_align(4, 8).unwrap();
+        unsafe {
+            let allocator = Allocator::new();
+            assert!(allocator.alloc(layout).is_null());
+
+            allocator.init(SPACE.as_ptr() as usize, SPACE.len() * 8);
+
+            let ptr = allocator.alloc(layout);
+            assert!(!ptr.is_null());
+            allocator.dealloc(ptr, layout);
+        }
+    }
+}

--- a/mizu/lib/kalloc/src/imp.rs
+++ b/mizu/lib/kalloc/src/imp.rs
@@ -1,0 +1,32 @@
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ptr::{self, NonNull},
+};
+
+use buddy_system_allocator::Heap;
+use spin::Mutex;
+
+pub struct Allocator(Mutex<Heap<30>>);
+
+impl Allocator {
+    pub const fn new() -> Self {
+        Allocator(Mutex::new(Heap::new()))
+    }
+
+    pub unsafe fn init(&self, start: usize, len: usize) {
+        ksync::critical(|| self.0.lock().init(start, len));
+    }
+}
+
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let res = ksync::critical(|| self.0.lock().alloc(layout));
+        res.map_or(ptr::null_mut(), NonNull::as_ptr)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if let Some(ptr) = NonNull::new(ptr) {
+            ksync::critical(|| self.0.lock().dealloc(ptr, layout))
+        }
+    }
+}

--- a/mizu/lib/kalloc/src/lib.rs
+++ b/mizu/lib/kalloc/src/lib.rs
@@ -1,0 +1,21 @@
+#![cfg_attr(not(test), no_std)]
+#![feature(once_cell)]
+
+mod imp;
+
+#[global_allocator]
+static GLOBAL_ALLOC: imp::Allocator = imp::Allocator::new();
+
+/// Initialize the kernel heap
+///
+/// # Safety
+///
+/// - `end` must be greater than `start` in addresses and must be properly
+///   aligned.
+/// - Must be called only once at initialization.
+pub unsafe fn init<T: Copy>(start: &mut T, end: &mut T) {
+    let start_ptr = (start as *mut T).cast();
+    let end_ptr = (end as *mut T).cast::<u8>();
+    let len = end_ptr.offset_from(start_ptr);
+    GLOBAL_ALLOC.init(start_ptr as usize, len as usize)
+}

--- a/mizu/lib/kalloc/src/lib.rs
+++ b/mizu/lib/kalloc/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod imp;
 
+#[cfg(not(test))]
 #[global_allocator]
 static GLOBAL_ALLOC: imp::Allocator = imp::Allocator::new();
 
@@ -13,6 +14,7 @@ static GLOBAL_ALLOC: imp::Allocator = imp::Allocator::new();
 /// - `end` must be greater than `start` in addresses and must be properly
 ///   aligned.
 /// - Must be called only once at initialization.
+#[cfg(not(test))]
 pub unsafe fn init<T: Copy>(start: &mut T, end: &mut T) {
     let start_ptr = (start as *mut T).cast();
     let end_ptr = (end as *mut T).cast::<u8>();

--- a/mizu/lib/klog/src/imp.rs
+++ b/mizu/lib/klog/src/imp.rs
@@ -12,7 +12,7 @@ impl Output {
         #[allow(deprecated)]
         let _ = sbi_rt::legacy::console_putchar(byte as usize);
         #[cfg(test)]
-        std::io::stdout().lock().write(&[byte]).unwrap()
+        std::io::stdout().lock().write(&[byte]).unwrap();
     }
 }
 

--- a/mizu/lib/ktime-core/src/instant.rs
+++ b/mizu/lib/ktime-core/src/instant.rs
@@ -10,16 +10,16 @@ pub struct Instant(u128);
 impl Instant {
     pub fn now() -> Self {
         let raw = riscv::register::time::read64() as u128;
-        let nanos = config::TIME_FREQ.reduced() * 1_000_000_000 * raw;
-        Instant(nanos.to_integer())
+        let micros = config::TIME_FREQ_M.numer() * raw / config::TIME_FREQ_M.denom();
+        Instant(micros)
     }
 
     #[must_use]
     pub fn checked_duration_since(&self, earlier: Self) -> Option<Duration> {
-        let nanos = self.0.checked_sub(earlier.0)?;
-        let secs = (nanos / 1_000_000_000) as u64;
-        let nanos = (nanos % 1_000_000_000) as u32;
-        Some(Duration::new(secs, nanos))
+        let micros = self.0.checked_sub(earlier.0)?;
+        let secs = (micros / 1_000_000) as u64;
+        let micros = (micros % 1_000_000) as u32;
+        Some(Duration::new(secs, micros))
     }
 
     #[must_use]
@@ -28,11 +28,11 @@ impl Instant {
     }
 
     pub fn checked_add(&self, duration: Duration) -> Option<Self> {
-        self.0.checked_add(duration.as_nanos()).map(Instant)
+        self.0.checked_add(duration.as_micros()).map(Instant)
     }
 
     pub fn checked_sub(&self, duration: Duration) -> Option<Self> {
-        self.0.checked_sub(duration.as_nanos()).map(Instant)
+        self.0.checked_sub(duration.as_micros()).map(Instant)
     }
 }
 
@@ -76,7 +76,7 @@ impl Sub for Instant {
 
 impl fmt::Debug for Instant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let display = self.0 as f64 / 1_000_000_000.0;
+        let display = self.0 as f64 / 1_000_000.0;
         fmt::Display::fmt(&display, f)
     }
 }


### PR DESCRIPTION
- Added kernel heap allocator
- Changed `ktime::Instant`'s representation from nanoseconds to microseconds.